### PR TITLE
Final tweaks before CRAN release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^inst/JOSS$
 ^cran-comments.md$
 .github
+^vignettes/tidyhydat_example_analysis.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: tidyhydat
-Title: Extract and Tidy Canadian Hydrometric Data
+Title: Extract and Tidy Canadian 'Hydrometric' Data
 Version: 0.3.0
 Authors@R: c(person("Sam", "Albers", email = "sam.albers@gov.bc.ca", role = c("aut", "cre")),
     person("David", "Hutchinson", email = "david.hutchinson@canada.ca", role = "ctb"),
@@ -9,7 +9,7 @@ Authors@R: c(person("Sam", "Albers", email = "sam.albers@gov.bc.ca", role = c("a
     person("Laura", "DeCicco", role = "rev", 
             comment = "Reviewed for rOpenSci, see <https://github.com/ropensci/onboarding/issues/118>")
     )
-Description: Provides functions to extract historical and real-time national hydrometric
+Description: Provides functions to extract historical and real-time national 'hydrometric'
     data from Water Survey of Canada data sources (<http://dd.weather.gc.ca/hydrometric/csv/> and
     <http://collaboration.cmc.ec.gc.ca/cmc/hydrometrics/www/>) and then applies tidy data principles.
 Depends: R (>= 3.4.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidyhydat
 Title: Extract and Tidy Canadian 'Hydrometric' Data
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(person("Sam", "Albers", email = "sam.albers@gov.bc.ca", role = c("aut", "cre")),
     person("David", "Hutchinson", email = "david.hutchinson@canada.ca", role = "ctb"),
     person("Province of British Columbia", role = "cph"),
@@ -19,8 +19,8 @@ BugReports: https://github.com/ropensci/tidyhydat/issues
 Encoding: UTF-8
 Imports:
     dplyr (>= 0.7.3),
-    dbplyr (>= 1.1.0),
     readr (>= 1.1.1),
+    dbplyr (>= 1.1.0),
     lubridate (>= 1.6.0),
     tidyr (>= 0.7.1),
     DBI (>= 0.7),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+tidyhydat 0.3.1
+=========================
+### NEW FEATURES
+
+  * When package is loaded, tidyhydat checks to see if HYDAT is even present
+  * When package is loaded, it now tests to see if their a new version of HYDAT if the current date is greater than 3 months after the last release date of HYDAT. 
+  * Prep for CRAN release
+  * Starting to use raw SQL for table queries
+  * Removing 2nd vignette from build. Still available on github
+
 tidyhydat 0.3.0 
 =========================
 

--- a/R/hy_stations.R
+++ b/R/hy_stations.R
@@ -92,7 +92,7 @@ hy_stations <- function(station_number = NULL,
   stns <- station_choice(hydat_con, station_number, prov_terr_state_loc)
 
   ## Create the dataframe to return
-  df <- dplyr::tbl(hydat_con, "STATIONS") %>%
+  df <- dplyr::tbl(hydat_con, dbplyr::sql("SELECT * FROM `STATIONS`")) %>%
     dplyr::filter(STATION_NUMBER %in% stns) %>%
     dplyr::collect() %>%
     dplyr::mutate(REGIONAL_OFFICE_ID = as.numeric(REGIONAL_OFFICE_ID)) %>%

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -112,7 +112,7 @@
   
   ## HYDAT is updated quarterly - should we go check if a new one is available for download?
   ## Only check when there is likely a new version i.e. about 3 months after last version
-  if(Sys.Date() > (as.Date(hy_version()$Date) + 10)){
+  if(file.exists(file.path(hy_dir(),"Hydat.sqlite3")) && Sys.Date() > (as.Date(hy_version()$Date) + 92)){
     packageStartupMessage("Checking for a new version of HYDAT...")
     base_url <- "http://collaboration.cmc.ec.gc.ca/cmc/hydrometrics/www/"
     x <- httr::GET(base_url)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -109,18 +109,27 @@
   if(!file.exists(file.path(hy_dir(),"Hydat.sqlite3"))){
     packageStartupMessage("Tidyhydat requires HYDAT which has not yet been downloaded. Download using download_hydat()")
   }
-#  
-#  ## Check the date of current HYDAT
-#  base_url <- "http://collaboration.cmc.ec.gc.ca/cmc/hydrometrics/www/"
-#  x <- httr::GET(base_url)
-#  httr::stop_for_status(x)
-#  new_hydat <- substr(gsub(
-#    "^.*\\Hydat_sqlite3_", "",
-#    httr::content(x, "text")
-#  ), 1, 8)
-#
-#  # Do we need to download a new version?
-#  if (!(as.Date(new_hydat, "%Y%m%d") == as.Date(hy_version()$Date))) {
-#    packageStartupMessage(paste0("A new version of HYDAT was release on ", as.Date(new_hydat, "%Y%m%d"),". Use download_hydat() to get the new version."))
-#  }
+  
+  ## HYDAT is updated quarterly - should we go check if a new one is available for download?
+  ## Only check when there is likely a new version i.e. about 3 months after last version
+  if(Sys.Date() > (as.Date(hy_version()$Date) + 10)){
+    packageStartupMessage("Checking for a new version of HYDAT...")
+    base_url <- "http://collaboration.cmc.ec.gc.ca/cmc/hydrometrics/www/"
+    x <- httr::GET(base_url)
+    httr::stop_for_status(x)
+    
+    ## Extract newest HYDAT
+    new_hydat <- as.Date(substr(gsub(
+      "^.*\\Hydat_sqlite3_", "",
+      httr::content(x, "text")
+    ), 1, 8),  "%Y%m%d")
+    
+    ## Compare that to existing HYDAT
+    if (new_hydat != as.Date(hy_version()$Date)){
+      packageStartupMessage(paste0("Your version of HYDAT is out of date. Use download_hydat() to get the new version."))
+    } else{
+      packageStartupMessage("No new version of HYDAT")
+    }
+  }
+
 }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,21 +1,20 @@
 ## Test environments
 
-* local Windows 7, R 3.4.2
-* ubuntu, os x, R 3.4.2 (travis-ci)
+* local Windows 7, R 3.4.3
+* ubuntu, R 3.4.3 (travis-ci)
 * win-builder (devel and release)
-* Windows 10, R 3.4.2 
+* local Windows 10, R 3.4.3 
+* Debian Linux, R-release, GCC (debian-gcc-release) - r-hub
+* macOS 10.11 El Capitan, R-release (experimental) - r-hub
+
 
 ## R CMD check results
 
 There were no ERRORs or WARNINGs.
 
-There was 1 NOTE:
-
-Possibly mis-spelled words in DESCRIPTION:
-  Hydrometric (2:34)
-  hydrometric (7:78)
-  
-All words are correctly spelled. 
+One NOTE:
+* checking data for non-ASCII characters ... NOTE
+  Note: found 7 marked UTF-8 strings
 
 ## Downstream dependencies
 


### PR DESCRIPTION
tidyhydat 0.3.1
=========================
### NEW FEATURES

  * When package is loaded, tidyhydat checks to see if HYDAT is even present
  * When package is loaded, it now tests to see if their a new version of HYDAT if the current date is greater than 3 months after the last release date of HYDAT. 
  * Prep for CRAN release
  * Starting to use raw SQL for table queries
  * Removing 2nd vignette from build. Still available on github