### PR TITLE
Update download_hydat to have an option to bypass the keypress question

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+### MINOR IMPROVEMENT
+* `download_hydat()` now has an `ask` parameter that can be used to bypass the keypress confirmation when downloading the HYDAT database (@rchlumsk, #165). 
+
 # tidyhydat 0.5.4
 - When add a local timezone column, use the most common timezone in the data rather than the first one. This just seems more likely to be useful to users
 - Add more documentation to `realtime_add_local_datetime` to make how timezones are dealt with clearer (#157)

--- a/R/download.R
+++ b/R/download.R
@@ -27,7 +27,7 @@
 #' }
 #'
 
-download_hydat <- function(dl_hydat_here = NULL, ask=TRUE) {
+download_hydat <- function(dl_hydat_here = NULL, ask = TRUE) {
   
   if(is.null(dl_hydat_here)){
     dl_hydat_here <- hy_dir()

--- a/R/download.R
+++ b/R/download.R
@@ -39,7 +39,7 @@ download_hydat <- function(dl_hydat_here = NULL, ask = TRUE) {
     }
   }
 
-  if (!is.logical(ask)) stop("Parameter ask must be a boolean")
+  if (!is.logical(ask)) stop("Parameter ask must be a logical")
   
   if (ask) {
     ans <- ask(paste("Downloading HYDAT will take ~10 minutes.","This will remove any older versions of HYDAT",

--- a/R/download.R
+++ b/R/download.R
@@ -46,6 +46,7 @@ download_hydat <- function(dl_hydat_here = NULL, ask = TRUE) {
                      "Is that okay?", sep = "\n"))
   } else {
     ans <- TRUE
+    green_message(paste0("Downloading HYDAT to ", normalizePath(dl_hydat_here)))
   }
   
   if (!ans) stop("Maybe another day...", call. = FALSE)

--- a/R/download.R
+++ b/R/download.R
@@ -19,6 +19,7 @@
 #' @param dl_hydat_here Directory to the HYDAT database. The path is chosen by the `rappdirs` package and is OS specific and can be view by [hy_dir()]. 
 #' This path is also supplied automatically to any function that uses the HYDAT database. A user specified path can be set though this is not the advised approach. 
 #' It also downloads the database to a directory specified by [hy_dir()].
+#' @param ans Answer (as boolean) can be provided to avoid keypress in function execution.
 #' @export
 #'
 #' @examples \dontrun{
@@ -26,7 +27,7 @@
 #' }
 #'
 
-download_hydat <- function(dl_hydat_here = NULL) {
+download_hydat <- function(dl_hydat_here = NULL, ans=NULL) {
   
   if(is.null(dl_hydat_here)){
     dl_hydat_here <- hy_dir()
@@ -38,11 +39,17 @@ download_hydat <- function(dl_hydat_here = NULL) {
     }
   }
 
-  ans <- ask(paste("Downloading HYDAT will take ~10 minutes.","This will remove any older versions of HYDAT",
-                   "Is that okay?", sep = "\n"))
+  if (is.null(ans)) {
+    ans <- ask(paste("Downloading HYDAT will take ~10 minutes.","This will remove any older versions of HYDAT",
+                     "Is that okay?", sep = "\n"))
+  } else {
+    if (ans != TRUE & ans != FALSE) {
+      stop("Parameter ans must be a boolean")
+    }
+  }
+  
   if (!ans) stop("Maybe another day...", call. = FALSE)
   
-
   info(paste0("Downloading HYDAT.sqlite3 to ", crayon::blue(dl_hydat_here)))
 
 

--- a/R/download.R
+++ b/R/download.R
@@ -19,7 +19,7 @@
 #' @param dl_hydat_here Directory to the HYDAT database. The path is chosen by the `rappdirs` package and is OS specific and can be view by [hy_dir()]. 
 #' This path is also supplied automatically to any function that uses the HYDAT database. A user specified path can be set though this is not the advised approach. 
 #' It also downloads the database to a directory specified by [hy_dir()].
-#' @param ans Answer (as boolean) can be provided to avoid keypress in function execution.
+#' @param ask Whether to ask (as \code{TRUE}/\code{FALSE}) if HYDAT should be downloaded. If \code{FALSE} the keypress question is skipped.
 #' @export
 #'
 #' @examples \dontrun{
@@ -27,7 +27,7 @@
 #' }
 #'
 
-download_hydat <- function(dl_hydat_here = NULL, ans=NULL) {
+download_hydat <- function(dl_hydat_here = NULL, ask=TRUE) {
   
   if(is.null(dl_hydat_here)){
     dl_hydat_here <- hy_dir()
@@ -39,13 +39,13 @@ download_hydat <- function(dl_hydat_here = NULL, ans=NULL) {
     }
   }
 
-  if (is.null(ans)) {
+  if (!is.logical(ask)) stop("Parameter ask must be a boolean")
+  
+  if (ask) {
     ans <- ask(paste("Downloading HYDAT will take ~10 minutes.","This will remove any older versions of HYDAT",
                      "Is that okay?", sep = "\n"))
   } else {
-    if (ans != TRUE & ans != FALSE) {
-      stop("Parameter ans must be a boolean")
-    }
+    ans <- TRUE
   }
   
   if (!ans) stop("Maybe another day...", call. = FALSE)

--- a/man/download_hydat.Rd
+++ b/man/download_hydat.Rd
@@ -4,12 +4,14 @@
 \alias{download_hydat}
 \title{Download and set the path to HYDAT}
 \usage{
-download_hydat(dl_hydat_here = NULL)
+download_hydat(dl_hydat_here = NULL, ask = TRUE)
 }
 \arguments{
 \item{dl_hydat_here}{Directory to the HYDAT database. The path is chosen by the \code{rappdirs} package and is OS specific and can be view by \code{\link[=hy_dir]{hy_dir()}}.
 This path is also supplied automatically to any function that uses the HYDAT database. A user specified path can be set though this is not the advised approach.
 It also downloads the database to a directory specified by \code{\link[=hy_dir]{hy_dir()}}.}
+
+\item{ask}{Whether to ask (as \code{TRUE}/\code{FALSE}) if HYDAT should be downloaded. If \code{FALSE} the keypress question is skipped.}
 }
 \description{
 Download the HYDAT sqlite database. This database contains all the historical hydrometric data for Canada's integrated hydrometric network.


### PR DESCRIPTION
Small update to download_hydat to add a parameter `ask`, which will bypass the keypress question and proceed directly to the download of HYDAT if `ask=FALSE`. Default `ask=TRUE` makes no change to  the existing workflow with the function.

Implemented to have an option for bypassing the keypress when using `download_hydat` in another function or other situations when the keypress is not ideal.