### PR TITLE
Custom hydat download path fix

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -133,7 +133,7 @@ download_hydat <- function(dl_hydat_here = NULL, ask = TRUE) {
       not_done("HYDAT not successfully downloaded")
     }
 
-    hy_check()
+    hy_check(hydat_path)
 
     invisible(hydat_path)
   } # End of DL and overwrite if statement


### PR DESCRIPTION
Previously if you supplied a 'dl_hydat_here' argument to the 'download_hydat' function it would make it all they way to the end of the function correctly, but then it calls hy_check with no argument. Which does not consider your custom path and causes an error. By supplying the path as an argument it fixes the 'download_hydat' function.