### PR TITLE
Fixes 192: Use file.copy for cross-disk flexibility in HYDAT download

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-- fix bug where download_hydat() fails if tempdir() is on a different device than hydat_path (@mpdavison, #192)
+- fix bug where `download_hydat()` fails if `tempdir()` is on a different device than `hydat_path` (@mpdavison, #192)
 
 # tidyhydat 0.6.1
 - Add `...` to print methods so you can pass arguments all the way down. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+- fix bug where download_hydat() fails if tempdir() is on a different device than hydat_path (@mpdavison, #192)
+
 # tidyhydat 0.6.1
 - Add `...` to print methods so you can pass arguments all the way down. 
 - Add workaround for vroom#519 bug that prevents `realtime_*` functions from working

--- a/R/download.R
+++ b/R/download.R
@@ -121,7 +121,7 @@ download_hydat <- function(dl_hydat_here = NULL, ask = TRUE) {
     on.exit(unlink(tempdir, recursive = TRUE))
 
     ## Move to final resting place and rename to consistent name
-    file.rename(
+    file.copy(
       list.files(tempdir, pattern = "\\.sqlite3$", full.names = TRUE),
       hydat_path
     )

--- a/R/download.R
+++ b/R/download.R
@@ -123,7 +123,8 @@ download_hydat <- function(dl_hydat_here = NULL, ask = TRUE) {
     ## Move to final resting place and rename to consistent name
     file.copy(
       list.files(tempdir, pattern = "\\.sqlite3$", full.names = TRUE),
-      hydat_path
+      hydat_path,
+      overwrite = TRUE
     )
 
 


### PR DESCRIPTION
Replaced file.rename with file.copy to handle situations where the temp folder and the destination are on different physical disks (e.g. Docker container with different mount points for the tempdir and the destination).